### PR TITLE
make sure routeInfo object is ready to avoid root path error

### DIFF
--- a/lib/guard.js
+++ b/lib/guard.js
@@ -1,9 +1,9 @@
 function guard (path, user, options) {
   const routeInfo = options.routes.match(path)
-  const given = (user && user.scope) || []
-  const required = routeInfo.scope
+  const given = (user && user?.scope) || []
+  const required = routeInfo?.scope
 
-  if (routeInfo.auth === false || required.find(s => given.includes(s))) {
+  if (!routeInfo || routeInfo.auth === false || required.find(s => given.includes(s))) {
     return options.grant && options.grant()
   }
 


### PR DESCRIPTION
for some reason if we dont unrestrict root path ("/"),  app(serverside) throw error ```TypeError: Cannot read property 'scope' of undefined```
on refresh page.